### PR TITLE
Updated Opauth's repo location

### DIFF
--- a/public/js/main.js
+++ b/public/js/main.js
@@ -101,7 +101,7 @@ require(
     'cheeaun/hackerweb',
     'MugunthKumar/MKStoreKit',
     //'zz85/sparks.js',
-    'uzyn/opauth',
+    'opauth/opauth',
     'honcheng/RTLabel',
     'honcheng/PaperFoldMenuController',
     // 'hboon/GlassButtons',


### PR DESCRIPTION
Just moved Opauth to `opauth/opauth`.

Thanks for updating.
